### PR TITLE
Update pagetualRules.json

### DIFF
--- a/Pagetual/pagetualRules.json
+++ b/Pagetual/pagetualRules.json
@@ -268,7 +268,7 @@
   },
   {
     "name":"秀人网",
-    "url":"^https://www\\.(imn5|jpxgmn|jpxgyw|jpmnb|jpmn8|xiurenji|xiurenb)\\.(com|net|vip|top|cc)/.*\\.html",
+    "url":"^https://www\\.(?:imn5|mntp|jpmnb|jpmn8|mn5|xgmn|jpxgmn|jpxgyw|xiurenji|xiurenb|xrmn|xrmn5)\\.(?:com|net|vip|cc|top)/.*\\.html",
     "pageElement":"p>img",
     "author":"bmp4cwa"
   },


### PR DESCRIPTION
更新一下 秀人网 域名 😁
其中，[[NSFW] xrmn5](https://www.xrmn5.com/XiuRen/2021/20218466.html) 有小问题，图片会插到页尾的求赞助图片下，不知是否是 BUG 。单独写 `div>p>img` 可以解决，但还是合在一起算了，又不是不能用 😁