### PR TITLE
Fixed: Ad filter might cause small size images to fail to load in some scenes

### DIFF
--- a/Picviewer CE+/Picviewer CE+.user.js
+++ b/Picviewer CE+/Picviewer CE+.user.js
@@ -20473,6 +20473,7 @@ ImgOps | https://imgops.com/#b#`;
                             gallery=new GalleryC();
                         };
                         gallery.load(this.data,this.from);
+                        gallery.changeMinView();
                         break;
                     case 'magnifier':
                         new MagnifierC(this.img,this.data);


### PR DESCRIPTION
以一个比较笨拙的方式解决了这个反馈里面的问题：https://greasyfork.org/zh-CN/scripts/24204-picviewer-ce/discussions/151423