### PR TITLE
Update Greasyfork Search with Sleazyfork Results include.user.js

### DIFF
--- a/Greasyfork Search with Sleazyfork Results include/Greasyfork Search with Sleazyfork Results include.user.js
+++ b/Greasyfork Search with Sleazyfork Results include/Greasyfork Search with Sleazyfork Results include.user.js
@@ -301,6 +301,7 @@
         var okCount=parseInt(script.querySelector("dd.script-list-ratings>span>.ok-rating-count").innerHTML.replace(/[^\d]/g,""));
         var badCount=parseInt(script.querySelector("dd.script-list-ratings>span>.bad-rating-count").innerHTML.replace(/[^\d]/g,""));
         if(badCount && badCount>goodCount){
+            if (badCount === 1) { return; }
             let scriptLink=script.querySelector('.script-link');
             if(scriptLink){
                 var warn=document.createTextNode("⚠");


### PR DESCRIPTION
I recently came across your project and found it quite useful. While working with it, I noticed a small issue regarding the display of scripts with a low number of reviews. Specifically, I observed that when a script has only one bad review, it can make the script appear as if it's of low quality, even though it might just be a single negative review.

To address this concern, I've made a pull request with a small change in the code. The idea is to prevent the application of the "scary title style" when there's only one bad review, as it might not accurately represent the script's overall quality.

Here's the code snippet I modified:

```js
var okCount = parseInt(script.querySelector("dd.script-list-ratings>span>.ok-rating-count").innerHTML.replace(/[^\d]/g, ""));
var badCount = parseInt(script.querySelector("dd.script-list-ratings>span>.bad-rating-count").innerHTML.replace(/[^\d]/g, ""));
if (badCount && badCount > goodCount) {
    if (badCount === 1) { return; }
    let scriptLink = script.querySelector('.script-link');
    if (scriptLink) {
        var warn = document.createTextNode("⚠");
```

Of course, there might be other ways to tackle this issue, and I'd be more than happy to discuss them with you. I hope this small change will help improve the user experience with your library.

Looking forward to your feedback!