### PR TITLE
修改东方永页机关于观察者网的翻页规则

### DIFF
--- a/Pagetual/pagetualRules.json
+++ b/Pagetual/pagetualRules.json
@@ -10464,9 +10464,7 @@
     "name": "观察者网",
     "url": "^https?://www\\.guancha\\.cn/",
     "example": "https://www.guancha.cn/economy/2023_10_27_713575_2.shtml",
-    "nextLink": "a.next",
-    "pageElement": ".comment-list > ul.list-body.list-body-all > li.comment-item.cmt-item",
-    "include": "#comments-container",
+    "pageElement": "div[class='content all-txt']",
     "waitElement": "a.next"
 },
 {


### PR DESCRIPTION
原规则会重复加载评论区和推荐文章