### PR TITLE
Fixed MAL Advance Search Hover

### DIFF
--- a/Pagetual/pagetualRules.json
+++ b/Pagetual/pagetualRules.json
@@ -10736,7 +10736,7 @@
     ],
     "pageElement": ".js-categories-seasonal>table",
     "replaceElement": ".spaceit>span",
-    "action": 0,
+    "action": 2,
     "pageNum": "&show={50*($p-1)}",
     "stopSign": "let pageList=doc.querySelector('.spaceit>span').textContent;let status=pageList.match(/(\\[\\d+\\])$/);if(status!=null)return true;"
 },


### PR DESCRIPTION
Some of the contents and CSS properties doesn't load properly because of action 0. In order make the search results more functional and make hover effect to work used action 2.