### PR TITLE
fix: pagetual.user.js prevent page scrolling when press down Shift/Ctrl/Alt

### DIFF
--- a/Pagetual/pagetual.user.js
+++ b/Pagetual/pagetual.user.js
@@ -8141,6 +8141,9 @@
         }
         if (rulesData.arrowToScroll) {
             keyupHandler = e => {
+                if (e.shiftKey || e.ctrlKey || e.altKey) {
+                    return;
+                }
                 if (document.activeElement &&
                     (compareNodeName(document.activeElement, ["input", "textarea"]) ||
                      document.activeElement.contentEditable == 'true')) {


### PR DESCRIPTION
当Shift键被按下时，通常，这是为了选中某段文本，Ctrl键则对应单词。

因此，在这时候不应该响应方向键滚动页面的功能。