### PR TITLE
Update Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hoothin/UserScripts&type=Date)](https://star-history.com/#hoothin/UserScripts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hoothin/UserScripts&type=Date)](https://star-history.dera.page/#hoothin/UserScripts&Date)


### PR DESCRIPTION
The current star history chart is no longer rendering because it relies on the GitHub stargazer API, which is heavily rate limited. This switches the chart to a working alternative that does not require an API token, keeping the same chart and badge style. Only the README link and chart endpoint are updated.